### PR TITLE
适配桌面端和横屏的展示效果

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title><%=VITE_APP_TITLE%></title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app" class="root"></div>
     <script type="module" src="/src/main.ts"></script>
     <script
       src="https://connect.qq.com/qc_jssdk.js"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-vue": "9.4.0",
     "mockjs": "^1.1.0",
     "npm-run-all": "^4.1.5",
-    "postcss-px-to-viewport": "^1.1.1",
+    "postcss-mobile-to-multi-displays": "^1.3.1",
     "prettier": "^2.7.1",
     "sass": "^1.54.9",
     "typescript": "~4.7.4",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,13 @@
 // eslint-disable-next-line no-undef
 module.exports = {
   plugins: {
-    'postcss-px-to-viewport': {
+    'postcss-mobile-to-multi-displays': {
       // 设备宽度375计算vw的值
-      viewportWidth: 375
+      viewportWidth: 375,
+      // 打开移动端的 vw 转换
+      enableMobile: true,
+      // 桌面端或横屏时居中的根元素
+      rootClass: 'root'
     }
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -64,3 +64,6 @@ ol {
   background-color: var(--cp-primary) !important;
 }
 
+.root {
+  position: relative;
+}


### PR DESCRIPTION
你好，欢迎试下我写的这个移动端适配插件，它可以像 px-to-viewport 那样生成视口单位，同时也可以限制最大宽度，防止发生屏幕过大字体过大的问题，我这个插件也适配了移动端横屏的情况。我认为这是移动端适配必须要做的，因为这样可以保证每个端的可访问性。
px-to-viewport 关于 vw 转换的功能我全都兼容了，所有的测试用例都能通过，感谢使用！